### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ The package can be installed as:
         def deps do
           [{:not_qwerty123, "~> 2.0"}]
         end
+  2. List `not_qwerty123` as an application dependency:
+  
+        def application do
+          [applications: [:logger, :not_qwerty123]]
+        end


### PR DESCRIPTION
`not_qwerty123` should be listed in application. Or I will get error:

```
exited in: GenServer.call(NotQwerty123.WordlistManager, {:query, "ncczemxple6p"}, 5000) ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
```